### PR TITLE
Allow passing multiple arguments to Format methods

### DIFF
--- a/src/ValueConverters/StringFormatConverter.cs
+++ b/src/ValueConverters/StringFormatConverter.cs
@@ -38,12 +38,12 @@ namespace WPFLocalizeExtension.ValueConverters
                     // try to load SmartFormat Assembly
                     var asSmartFormat = Assembly.Load("SmartFormat");
                     var tt = asSmartFormat.GetType("SmartFormat.Smart");
-                    miFormat = tt.GetMethod("Format", BindingFlags.Static | BindingFlags.Public, null, new Type[] { typeof(string), typeof(object) }, null);
+                    miFormat = tt.GetMethod("Format", BindingFlags.Static | BindingFlags.Public, null, new Type[] { typeof(string), typeof(object[]) }, null);
                 }
                 catch
                 {
                     // fallback just take String.Format
-                    miFormat = typeof(string).GetMethod("Format", BindingFlags.Static | BindingFlags.Public, null, new Type[] { typeof(string), typeof(object) }, null);
+                    miFormat = typeof(string).GetMethod("Format", BindingFlags.Static | BindingFlags.Public, null, new Type[] { typeof(string), typeof(object[]) }, null);
                 }
             }
 
@@ -59,7 +59,7 @@ namespace WPFLocalizeExtension.ValueConverters
             if (values.Length > 1 && values[1] == DependencyProperty.UnsetValue)
                 return null;
 
-            return (string)miFormat.Invoke(null, values);
+            return (string)miFormat.Invoke(null, new[] { values[0], values.Skip(1).ToArray() });
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
As it currently stands, a `MultiBinding` like the one below would cause an error due to a parameter count mismatch in the `miFormat.Invoke` line:

```xaml
<MultiBinding Converter="{StaticResource StringFormatConverter}">
    <lex:BLoc Key="MyKeyWithTwoPlaceHolders"/>
    <Binding Path="ValueForPlaceHolder0"/>
    <Binding Path="ValueForPlaceHolder1"/>
</MultiBinding>
```

This is because the method being captured via reflection is `string.Format(string format, object arg0)` (or the equivalent one in the SmartFormat library).

With these changes, the method being captured would be `string.Format(string format, params object[] args)` instead, hence allowing for an arbitrary number of format parameters instead.