### PR TITLE
Optimized work with Listener list

### DIFF
--- a/src/Engine/ListenerList.cs
+++ b/src/Engine/ListenerList.cs
@@ -1,0 +1,112 @@
+﻿namespace WPFLocalizeExtension.Engine
+{
+    #region Usings
+    
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    
+    #endregion
+    
+    /// <summary>
+    /// Represents a collection of listeners.
+    /// </summary>
+    internal class ListenersList
+    {
+        private readonly Dictionary<WeakReference, int> listeners;
+        private readonly Dictionary<int, List<WeakReference>> listenersHashCodes;
+        private readonly List<WeakReference> deadListeners;
+
+        /// <summary>
+        /// Create new empty <see cref="ListenersList" /> instance.
+        /// </summary>
+        public ListenersList()
+        {
+            listeners = new Dictionary<WeakReference, int>();
+            listenersHashCodes = new Dictionary<int, List<WeakReference>>();
+            deadListeners = new List<WeakReference>();
+        }
+
+        /// <summary>
+        /// The count of listeners.
+        /// </summary>
+        public int Count => listeners.Count;
+
+        /// <summary>
+        /// Add new listener.
+        /// </summary>
+        public void AddListener(IDictionaryEventListener listener)
+        {
+            // Add listener if it not registered yet.
+            var weakReference = new WeakReference(listener);
+            var hashCode = listener.GetHashCode();
+            if (!listenersHashCodes.TryGetValue(hashCode, out var sameHashCodeListeners))
+            {
+                listeners.Add(weakReference, hashCode);
+                listenersHashCodes.Add(hashCode, new List<WeakReference> { weakReference });
+            }
+            else if (sameHashCodeListeners.All(wr => wr.Target != listener))
+            {
+                listeners.Add(weakReference, hashCode);
+                sameHashCodeListeners.Add(weakReference);
+            }
+        }
+
+        /// <summary>
+        /// Get all alive listeners.
+        /// </summary>
+        public IEnumerable<IDictionaryEventListener> GetListeners()
+        {
+            foreach (var listener in listeners)
+            {
+                var listenerReference = listener.Key.Target as IDictionaryEventListener;
+                if (listenerReference == null)
+                {
+                    deadListeners.Add(listener.Key);
+                    continue;
+                }
+
+                yield return listenerReference;
+            }
+        }
+
+        /// <summary>
+        /// Remove listener.
+        /// </summary>
+        public void RemoveListener(IDictionaryEventListener listener)
+        {
+            var hashCode = listener.GetHashCode();
+            if (!listenersHashCodes.TryGetValue(hashCode, out var hashCodes))
+                return;
+
+            var wr = hashCodes.FirstOrDefault(l => l.Target == listener);
+            if (wr == null)
+                return;
+
+            if (hashCodes.Count > 1)
+                hashCodes.Remove(wr);
+            else
+                listenersHashCodes.Remove(hashCode);
+
+            listeners.Remove(wr);
+        }
+
+        /// <summary>
+        /// Clear internal list from all dead listeners.
+        /// </summary>
+        public void ClearDeadReferences()
+        {
+            foreach (var deadListener in deadListeners)
+            {
+                var hashCode = listeners[deadListener];
+                listenersHashCodes[hashCode].Remove(deadListener);
+                if (!listenersHashCodes[hashCode].Any())
+                    listenersHashCodes.Remove(hashCode);
+
+                listeners.Remove(deadListener);
+            }
+
+            deadListeners.Clear();
+        }
+    }
+}

--- a/src/Engine/LocalizeDictionary.cs
+++ b/src/Engine/LocalizeDictionary.cs
@@ -969,7 +969,7 @@ namespace WPFLocalizeExtension.Engine
             /// <summary>
             /// The list of listeners
             /// </summary>
-            private static readonly List<WeakReference> Listeners = new List<WeakReference>();
+            private static readonly ListenersList Listeners = new ListenersList();
             private static readonly object ListenersLock = new object();
 
             /// <summary>
@@ -979,22 +979,15 @@ namespace WPFLocalizeExtension.Engine
             /// <param name="args">The event arguments.</param>
             internal static void Invoke(DependencyObject sender, DictionaryEventArgs args)
             {
-                var list = new List<IDictionaryEventListener>();
-
                 lock (ListenersLock)
                 {
-                    foreach (var wr in Listeners.ToList())
+                    foreach (var listener in Listeners.GetListeners())
                     {
-                        var targetReference = wr.Target;
-                        if (targetReference != null)
-                            list.Add((IDictionaryEventListener)targetReference);
-                        else
-                            Listeners.Remove(wr);
+                        listener.ResourceChanged(sender, args);
                     }
+                    
+                    Listeners.ClearDeadReferences();
                 }
-
-                foreach (var item in list)
-                    item.ResourceChanged(sender, args);
             }
 
             /// <summary>
@@ -1005,24 +998,10 @@ namespace WPFLocalizeExtension.Engine
             {
                 if (listener == null)
                     return;
-
-                // Check, if this listener already was added.
-                bool listenerExists = false;
-
+                
                 lock (ListenersLock)
                 {
-                    foreach (var wr in Listeners.ToList())
-                    {
-                        var targetReference = wr.Target;
-                        if (targetReference == null)
-                            Listeners.Remove(wr);
-                        else if (targetReference == listener)
-                            listenerExists = true;
-                    }
-
-                    // Add it now.
-                    if (!listenerExists)
-                        Listeners.Add(new WeakReference(listener));
+                    Listeners.AddListener(listener);
                 }
             }
 
@@ -1037,14 +1016,7 @@ namespace WPFLocalizeExtension.Engine
 
                 lock (ListenersLock)
                 {
-                    foreach (var wr in Listeners.ToList())
-                    {
-                        var targetReference = wr.Target;
-                        if (targetReference == null)
-                            Listeners.Remove(wr);
-                        else if ((IDictionaryEventListener)targetReference == listener)
-                            Listeners.Remove(wr);
-                    }
+                    Listeners.RemoveListener(listener);
                 }
             }
 
@@ -1057,15 +1029,12 @@ namespace WPFLocalizeExtension.Engine
             {
                 lock (ListenersLock)
                 {
-                    foreach (var wr in Listeners.ToList())
+                    foreach (var listener in Listeners.GetListeners().OfType<T>())
                     {
-                        var targetReference = wr.Target;
-
-                        if (targetReference == null)
-                            Listeners.Remove(wr);
-                        else if (targetReference is T)
-                            yield return (T)targetReference;
+                        yield return listener;
                     }
+                    
+                    Listeners.ClearDeadReferences();
                 }
             }
         }


### PR DESCRIPTION
Listeners list has the same problems which had `NestedMarkupExtension`:
1. `AddListener` was O(N) + constant for deleting weak refernces + memory using for 'ToList()' call. Now - O(lnN).
2. `RemoveListener` was O(N) + constant for deleting dead weak refernces + memory using for 'ToList()' call. Now - O(lnN).
3. `Invoke` and `EnumerateListeners` has problem with memory ('ToList()' call) + deleting dead weak refernces. 

So, I hope this changing will increase perfomence on all operations with listener list.

p.s. Now `Invoke` method all executing under lock. It seems to me and I hope this won't have some bad effects 