### PR TITLE
ResX provider: create resource manager directly without needing VS studio or resgen to generate designer files

### DIFF
--- a/src/Providers/ResxLocalizationProviderBase.cs
+++ b/src/Providers/ResxLocalizationProviderBase.cs
@@ -470,6 +470,14 @@ namespace WPFLocalizeExtension.Providers
                     // remove ".resources" from the end
                     foundResource = foundResource.Substring(0, foundResource.Length - ResourceFileExtension.Length);
 
+                    if (TryCreateResourceManager(foundResource, assembly, out ResourceManager resourceManager))
+                    {
+                        CacheResourceManager(resManKey, resourceManager);
+
+                        return resourceManager;
+                    }
+
+
                     // First try the simple retrieval
                     Type resourceManagerType;
                     try
@@ -519,27 +527,47 @@ namespace WPFLocalizeExtension.Providers
                 if (resManager == null)
                     throw new ArgumentException(string.Format("No resource manager for dictionary '{0}' in assembly '{1}' found! ({1}.{0})", resourceDictionary, resourceAssembly));
 
-                // Add the ResourceManager to the cachelist
-                Add(resManKey, resManager);
-
-                try
-                {
-                    // Look in all cultures and check available ressources.
-                    foreach (var c in SearchCultures)
-                    {
-                        var rs = resManager.GetResourceSet(c, true, false);
-                        if (rs != null)
-                            AddCulture(c);
-                    }
-                }
-                catch
-                {
-                    // ignored
-                }
+                CacheResourceManager(resManKey, resManager);
             }
 
             // return the found ResourceManager
             return resManager;
+        }
+
+        private void CacheResourceManager(string resManKey, ResourceManager resManager)
+        {
+            // Add the ResourceManager to the cachelist
+            Add(resManKey, resManager);
+
+            try
+            {
+                // Look in all cultures and check available ressources.
+                foreach (var c in SearchCultures)
+                {
+                    var rs = resManager.GetResourceSet(c, true, false);
+                    if (rs != null)
+                        AddCulture(c);
+                }
+            }
+            catch
+            {
+                // ignored
+            }
+        }
+
+        private bool TryCreateResourceManager(string resourceManagerBaseName, Assembly resourceManagerAssembly, out ResourceManager resourceManager)
+        {
+            try
+            {
+                resourceManager = new ResourceManager(resourceManagerBaseName, resourceManagerAssembly);
+            }
+            catch
+            {
+                resourceManager = null;
+            }
+
+            return resourceManager != null;
+
         }
 
         private ResourceManager GetResourceManagerFromType(IReflect type)
@@ -561,9 +589,9 @@ namespace WPFLocalizeExtension.Providers
                 return null;
             }
         }
-        #endregion
+#endregion
 
-        #region ILocalizationProvider implementation
+#region ILocalizationProvider implementation
         /// <summary>
         /// Uses the key and target to build a fully qualified resource key (Assembly, Dictionary, Key)
         /// </summary>
@@ -711,6 +739,6 @@ namespace WPFLocalizeExtension.Providers
         /// An observable list of available cultures.
         /// </summary>
         public ObservableCollection<CultureInfo> AvailableCultures { get; protected set; }
-        #endregion
+#endregion
     }
 }


### PR DESCRIPTION
In an application I am working on my team have created a tool to extract localizable xaml properties and generate resx files automatically. The issue we have is that out tool is generating the resx files outside of Visual Studio. This means that the ResXFileCodeGenerator custom tool is not executed by Visual Studio (unless we run Resgen.exe manually or open each of the generated files in Visual Studio).

The library is making an assumption that the strongly-typed resource class (generated by ResXFileCodeGenerator custom tool in VS or by Resgen.exe) will exist. The assembly will still contains the actual .resources file despite these tools not being ran but the library will not load the resources, as the type can't be found. From the assembly name and dictionary name we can attempt to create a new resource manager manually by assuming that if if we have a .resources file embedded in the assembly which matches the assembly name + dictionary name then we can attempt to manually create an instance of it.
