### PR TITLE
Added FallbackBehavior support

### DIFF
--- a/src/Engine/FallbackBehavior.cs
+++ b/src/Engine/FallbackBehavior.cs
@@ -1,0 +1,23 @@
+﻿namespace WPFLocalizeExtension.Engine
+{
+    /// <summary>
+    /// Behavior when key is not found at the localization provider.
+    /// </summary>
+    public enum FallbackBehavior
+    {
+        /// <summary>
+        /// Display "Key: {key}" string.
+        /// </summary>
+        Default,
+        
+        /// <summary>
+        /// Display key string itself.
+        /// </summary>
+        Key,
+        
+        /// <summary>
+        /// Display an empty string.
+        /// </summary>
+        EmptyString
+    }
+}

--- a/src/Extensions/LocExtension.cs
+++ b/src/Extensions/LocExtension.cs
@@ -264,6 +264,12 @@ namespace WPFLocalizeExtension.Extensions
             get => _key ?? "(null)";
             set => _key = value.ToString();
         }
+        
+        /// <summary>
+        /// Behavior when key is not found at the localization provider.
+        /// </summary>
+        public FallbackBehavior FallbackBehavior { get; set; }
+        
         #endregion
 
         #region Constructors
@@ -606,7 +612,23 @@ namespace WPFLocalizeExtension.Extensions
                         if (missingKeyEventResult.MissingKeyResult != null)
                             result = missingKeyEventResult.MissingKeyResult;
                         else
-                            result = "Key: " + _key;
+                        {
+                            switch (FallbackBehavior)
+                            {
+                                case FallbackBehavior.Key:
+                                    result = _key;
+                                    break;
+                                
+                                case FallbackBehavior.EmptyString:
+                                    result = string.Empty;
+                                    break;
+                                
+                                case FallbackBehavior.Default:
+                                default:
+                                    result = "Key: " + _key;
+                                    break;
+                            }
+                        }
                     }
                 }
             }

--- a/tests/HelloWorldWPF/MainWindow.xaml
+++ b/tests/HelloWorldWPF/MainWindow.xaml
@@ -77,6 +77,11 @@
         <TextBlock Text="{lex:Loc {Binding tenum, Converter={lex:PrependTypeConverter}, ConverterParameter=__}}"></TextBlock>
         <Button Name="BindeTestButton" Content="Press to toggle binded property" Margin="5" Click="BindeTestButton_Click" ></Button>
         <TextBlock Name="MyLabel2" FontSize="20" Text="{lex:Loc PresentationCore:ExceptionStringTable:DeleteText}" HorizontalAlignment="Center" />
+        <StackPanel Margin="20,0,0,0">
+            <TextBlock FontSize="20" Text="{lex:Loc UndefinedKey, FallbackBehavior=Default}" />
+            <TextBlock FontSize="20" Text="{lex:Loc UndefinedKey, FallbackBehavior=Key}" />
+            <TextBlock FontSize="20" Text="{lex:Loc UndefinedKey, FallbackBehavior=EmptyString}" />
+        </StackPanel>
         <StackPanel Orientation="Horizontal">
             <Button Content="{lex:Loc de}" Margin="5" CommandParameter="de" Command="{Binding Source={x:Static lex:LocalizeDictionary.Instance}, Path=SetCultureCommand}" />
             <Button Content="{lex:Loc en}" Margin="5" CommandParameter="en" Command="{Binding Source={x:Static lex:LocalizeDictionary.Instance}, Path=SetCultureCommand}" />

--- a/tests/HelloWorldWPF/MainWindow.xaml.cs
+++ b/tests/HelloWorldWPF/MainWindow.xaml.cs
@@ -48,6 +48,10 @@ namespace HalloWeltWPF
 
         private void Instance_MissingKeyEvent(object sender, MissingKeyEventArgs e)
         {
+            // Test of FallbackBehavior.
+            if (e.Key == "UndefinedKey")
+                return;
+            
             e.MissingKeyResult = "Hello World";
         }
 

--- a/tests/WPFLocalizeExtension.UnitTests/ValueConvertersTests/LocExtensionTests.cs
+++ b/tests/WPFLocalizeExtension.UnitTests/ValueConvertersTests/LocExtensionTests.cs
@@ -1,0 +1,87 @@
+﻿namespace WPFLocalizeExtension.UnitTests.ValueConvertersTests
+{
+    #region Usings
+    using Xunit;
+    using XAMLMarkupExtensions.Base;
+    using WPFLocalizeExtension.Engine;
+    using WPFLocalizeExtension.Extensions;
+    #endregion
+    
+    /// <summary>
+    /// Tests for <see cref="LocExtension" />.
+    /// </summary>
+    public class LocExtensionTests
+    {
+        #region FallbackBehavior
+
+        private const string MISSING_KEY_RESULT = nameof(MISSING_KEY_RESULT);
+        
+        /// <summary>
+        /// Check different behaviors when key is not found at resource provider.
+        /// </summary>
+        [Theory]
+        [InlineData(FallbackBehavior.Default, "Key: abacaba")]
+        [InlineData(FallbackBehavior.Key, "abacaba")]
+        [InlineData(FallbackBehavior.EmptyString, "")]
+        public void FormatOutput_SpecifiedFallbackBehavior_SpecifiedOutput(FallbackBehavior fallbackBehavior, string expectedValue)
+        {
+            // ARRANGE.
+            const string key = "abacaba";
+            
+            var locExtension = new LocExtension(key);
+            locExtension.FallbackBehavior = fallbackBehavior;
+            var endPoint = new TargetInfo(null, null, typeof(string), -1);
+            var info = new TargetInfo(null, null, typeof(string), -1);
+
+            // ACT.
+            var resultValue = locExtension.FormatOutput(endPoint, info);
+            
+            // ASSERT.
+            Assert.Equal(expectedValue, resultValue);
+        }
+
+        /// <summary>
+        /// Check if <see cref="LocalizeDictionary.MissingKeyEvent" /> specifies missing value, then <see cref="FallbackBehavior" /> is not used.
+        /// </summary>
+        [Theory]
+        [InlineData(FallbackBehavior.Default)]
+        [InlineData(FallbackBehavior.Key)]
+        [InlineData(FallbackBehavior.EmptyString)]
+        public void FormatOutput_MissingKeyEventHandling_FallbackBehaviorNotUsed(FallbackBehavior fallbackBehavior)
+        {
+            // ARRANGE.
+            const string key = "abacaba";
+            
+            var locExtension = new LocExtension(key);
+            locExtension.FallbackBehavior = fallbackBehavior;
+            var endPoint = new TargetInfo(null, null, typeof(string), -1);
+            var info = new TargetInfo(null, null, typeof(string), -1);
+
+            // ACT.
+            object resultValue;
+            LocalizeDictionary.Instance.MissingKeyEvent += OnMissingKeyEvent;
+            
+            try
+            {
+                resultValue = locExtension.FormatOutput(endPoint, info);
+            }
+            finally
+            {
+                LocalizeDictionary.Instance.MissingKeyEvent -= OnMissingKeyEvent;
+            }
+            
+            // ASSERT.
+            Assert.Equal(MISSING_KEY_RESULT, resultValue);
+        }
+
+        /// <summary>
+        /// Handle <see cref="LocalizeDictionary.MissingKeyEvent" />.
+        /// </summary>
+        private static void OnMissingKeyEvent(object sender, MissingKeyEventArgs e)
+        {
+            e.MissingKeyResult = MISSING_KEY_RESULT;
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Connected with #354

Now, it's possibly to specify fallback behavior:
``` xaml
<TextBlock Text="{lex:Loc UndefinedKey, FallbackBehavior=Default}" />
<TextBlock Text="{lex:Loc UndefinedKey, FallbackBehavior=Key}" />
<TextBlock Text="{lex:Loc UndefinedKey, FallbackBehavior=EmptyString}" />
```

It will be used only if key wasn't found anywhere, including `MissingKeyResult` event.

@konne, @superware, please check 